### PR TITLE
Add delete_balanced function

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,14 @@ require'nvim-treesitter.configs'.setup {
     goto_right_end = false, -- whether to go to the end of the right partner or the beginning
     fallback_cmd_normal = "call matchit#Match_wrapper('',1,'n')", -- What command to issue when we can't find a pair (e.g. "normal! %")
     keymaps = {
-      goto_partner = "<leader>%"
+      goto_partner = "<leader>%",
+      delete_balanced = "X",
+    },
+    delete_balanced = {
+      only_on_first_char = false, -- whether to trigger balanced delete when on first character of a pair
+      fallback_cmd_normal = nil, -- fallback command when no pair found, can be nil
+      longest_partner = false, -- whether to delete the longest or the shortest pair when multiple found.
+                               -- E.g. whether to delete the angle bracket or whole tag in  <pair> </pair>
     }
   }
 },

--- a/lua/nvim-treesitter-pairs.lua
+++ b/lua/nvim-treesitter-pairs.lua
@@ -19,7 +19,13 @@ function M.init()
       goto_right_end = false,
       fallback_cmd_normal = "call matchit#Match_wrapper('',1,'n')",
       keymaps = {
-        goto_partner = "<leader>%"
+        goto_partner = "<leader>%",
+        delete_balanced = "X",
+      },
+      delete_balanced = {
+        only_on_first_char = false,
+        fallback_cmd_normal = nil,
+        longest_partner = false,
       }
     }
   }


### PR DESCRIPTION
Essentially, you can remove both sides of a pair.

Two use cases:

- improved `x` (can be a bit slower than normal `x` until I improve the speed of `find_best_match`)
```lua
      keymaps = {
        goto_partner = "<leader>%",
        delete_balanced = "x",
      },
      delete_balanced = {
        only_on_first_char = true,
        fallback_cmd_normal = 'normal! x',
        longest_partner = true,
      }
```
- Just delete self and the highlighted partner
```lua
      keymaps = {
        goto_partner = "<leader>%",
        delete_balanced = "X",
      },
      delete_balanced = {
        only_on_first_char = false,
        fallback_cmd_normal = nil,
        longest_partner = false,
      }
```