### PR TITLE
Add curly to clojure

### DIFF
--- a/queries/clojure/pairs.scm
+++ b/queries/clojure/pairs.scm
@@ -1,1 +1,1 @@
-; inherits: paren,square
+; inherits: curly,square,paren


### PR DESCRIPTION
Hello, here is a tiny PR to add curly brackets to the clojure query. 

I've had this in my after/queries for a while, but I don't think there is a reason not to include it in the defaults?